### PR TITLE
Choose menu name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The approach with this starter is to treat Eleventy layouts as wrappers for stat
 
 Although JSX is used for the templates there is no connection to react and these components will be rendered to static HTML in the build process with no hydration.
 
-
 ### Prerequisites
 
 - [node](https://nodejs.org/) I recommend using [asdf](https://asdf-vm.com/) or other version manager.
@@ -47,7 +46,6 @@ As static sites are often hosted on CDNs it is a good idea to hash assets so you
 <link data-asset-hash href="/css/styles.css" rel="stylesheet" />
 ```
 
-
 ## Code & configs
 
 ### What it's for
@@ -62,9 +60,9 @@ As static sites are often hosted on CDNs it is a good idea to hash assets so you
 - `src/_config` entry point for [organizing the Eleventy config](https://www.lenesaile.com/en/blog/organizing-the-eleventy-config-file/)
 - `src/_includes` default layouts folder
 - `src/_components` components to be used by layouts or shortcodes
-- `./src/js/index.ts` entrypoint for compiling *client side* JS. Bundling options are set in `src/_config/bundle-javascript.ts`
+- `./src/js/index.ts` entrypoint for compiling _client side_ JS. Bundling options are set in `src/_config/bundle-javascript.ts`
 - `./src/css/styles.scss` entrypoint for compiling CSS add a `browserlist` entry to `package.json` or `.browserslistrc` to change lightningcss default targets
-- `./src/css/_vars.scss` collection of css variables used to build our styles, they include fluid units that can be visualized here; [colors](https://abc.useallfive.com/?colors[]=000000,FFFFFF,044156,4F81BD,65B891,F6F183,B48C87), [type scale]( https://utopia.fyi/type/calculator?c=320,18,1.2,1240,20,1.25,9,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12) and [spacing scale](https://utopia.fyi/space/calculator?c=320,18,1.2,1240,20,1.25,6,3,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-3xl|m-xl&g=s,l,xl,12)
+- `./src/css/_vars.scss` collection of css variables used to build our styles, they include fluid units that can be visualized here; [colors](https://abc.useallfive.com/?colors[]=000000,FFFFFF,044156,4F81BD,65B891,F6F183,B48C87), [type scale](https://utopia.fyi/type/calculator?c=320,18,1.2,1240,20,1.25,9,2,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-l&g=s,l,xl,12) and [spacing scale](https://utopia.fyi/space/calculator?c=320,18,1.2,1240,20,1.25,6,3,&s=0.75|0.5|0.25,1.5|2|3|4|6,s-3xl|m-xl&g=s,l,xl,12)
 
 ### baseURL
 
@@ -76,7 +74,6 @@ BASE_URL="https://sheffield.breathe-easy.uk" npm start
 
 This will then be accessed as `globalData` in templates under `data.baseURL`
 
-
 ## Content
 
 New pages can be added and edited through the Decap CMS available at [sheffield.breathe-easy.uk/admin](https://sheffield.breathe-easy.uk/admin). You can mess about in the [demo environment](https://demo.decapcms.org/) without effecting the site.
@@ -87,7 +84,8 @@ Pages accept the following front-matter.
 
 ```yaml
 layout: "which template to use"
-menu: (true | false) show page title in navigation, defaults to false
+menu: "(true | false) show page title in navigation, defaults to false"
+menuName: "Disaply name for menu item, if not supplied title will be used"
 title: "for pages h1 and opengraph metadata"
 description: "[optional] for opengraph metadata"
 socialImage: "[optional] for opengraph metadata (external link or path to file)"

--- a/eleventy.ts
+++ b/eleventy.ts
@@ -4,11 +4,11 @@ import { z } from "zod";
 
 const MenuSchema = z
   .object({
-    data: z.object({ title: z.string() }),
+    data: z.object({ title: z.string(), menuName: z.string().optional() }),
     url: z.string(),
   })
   .transform((entry) => ({
-    title: entry.data.title,
+    title: entry.data.menuName ? entry.data.menuName : entry.data.title,
     url: entry.url,
   }))
   .array();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsx node_modules/@11ty/eleventy/cmd.cjs --config=eleventy.config.ts",
-    "start": "tsx node_modules/@11ty/eleventy/cmd.cjs --config=eleventy.config.ts --serve --incremental",
+    "start": "tsx node_modules/@11ty/eleventy/cmd.cjs --config=eleventy.config.ts --serve",
     "test": "vitest watch"
   },
   "type": "module",

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -33,6 +33,13 @@ collections:
           hint: "Should this page be linked to from the navigation at the top of every page?",
         }
       - {
+          label: "Menu name",
+          name: "menuName",
+          widget: "string",
+          hint: "Disaply name for menu item, if not supplied title will be used",
+          required: false,
+        }
+      - {
           label: "Layout",
           name: "layout",
           widget: "select",


### PR DESCRIPTION
Some page titles might be too long to sit in a menu, let users define the menu name seperatly

`“how-to-guide-for-covid-safer-events” -> "guide"` 

if not provided will fallback to title.