### PR TITLE
FYI widget / element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@11ty/eleventy": "^3.1.2",
+        "@mdit/plugin-container": "^0.22.1",
         "@mobily/ts-belt": "^3.13.1",
         "@types/markdown-it": "^14.1.2",
         "cherio": "^1.0.0-rc.2",
@@ -371,6 +372,26 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true
+    },
+    "node_modules/@mdit/plugin-container": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@mdit/plugin-container/-/plugin-container-0.22.1.tgz",
+      "integrity": "sha512-UY1NRRb/Su9YxQerkCF8bWG0fY/V24b9f/jVWh5DhD+Dw4MifVbV6p5TlaeQ854Xz9prkhyXSugiWbjhju6BgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "markdown-it": "^14.1.0"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@mobily/ts-belt": {
       "version": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "description": "",
   "dependencies": {
     "@11ty/eleventy": "^3.1.2",
+    "@mdit/plugin-container": "^0.22.1",
     "@mobily/ts-belt": "^3.13.1",
     "@types/markdown-it": "^14.1.2",
     "cherio": "^1.0.0-rc.2",

--- a/src/_config/markdown-library.ts
+++ b/src/_config/markdown-library.ts
@@ -1,5 +1,6 @@
 import * as MarkdownIt from "markdown-it";
 import markdownItAnchor from "markdown-it-anchor";
+import { container, MarkdownItContainerOptions } from "@mdit/plugin-container";
 import slugify from "slugify";
 
 const linkAfterHeader = markdownItAnchor.permalink.linkAfterHeader({
@@ -40,8 +41,16 @@ const markdownItAnchorOptions = {
   },
 };
 
+const assideOptions: MarkdownItContainerOptions = {
+  name: "fyi",
+  openRender: (_) => "<aside class='fyi'>",
+  closeRender: (_) => "</aside>",
+};
+
 export const markdownLibrary = MarkdownIt.default({
   html: true,
   breaks: true,
   linkify: true,
-}).use(markdownItAnchor, markdownItAnchorOptions);
+})
+  .use(markdownItAnchor, markdownItAnchorOptions)
+  .use(container, assideOptions);

--- a/src/_config/markdown-library.ts
+++ b/src/_config/markdown-library.ts
@@ -43,7 +43,7 @@ const markdownItAnchorOptions = {
 
 const assideOptions: MarkdownItContainerOptions = {
   name: "fyi",
-  openRender: (_) => "<aside class='fyi'>",
+  openRender: (_) => "<aside class='fyi stack stack-gap-s'>",
   closeRender: (_) => "</aside>",
 };
 

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -8,6 +8,68 @@
   </head>
   <body>
     <!-- Include the script that builds the page and powers Decap CMS -->
+    <script src="https://unpkg.com/markdown-it@14.1.0/dist/markdown-it.min.js"></script>
     <script src="https://unpkg.com/decap-cms@^3.6.3/dist/decap-cms.js"></script>
+    <!-- https://decapcms.org/docs/custom-widgets/#registereditorcomponent -->
+    <script>
+      // TODO: it would be good if we pulled in the same markdown options as we use
+      // to build the site
+      const md = window.markdownit();
+
+      CMS.registerEditorComponent({
+        // Internal id of the component
+        id: "fyi-widget",
+        // Visible label
+        label: "FYI",
+        // Fields the user need to fill out when adding an instance of the component
+        fields: [
+          {
+            name: "contents",
+            label: "Contents",
+            widget: "markdown",
+          },
+        ],
+        // Regex pattern used to search for instances of this block in the markdown document.
+        // Patterns are run in a multiline environment (against the entire markdown document),
+        // and so generally should make use of the multiline flag (`m`). If you need to capture
+        // newlines in your capturing groups, you can either use something like
+        // `([\S\s]*)`, or you can additionally enable the "dot all" flag (`s`),
+        // which will cause `(.*)` to match newlines as well.
+        //
+        // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
+        // `(.*?)` vs `(.*)`), especially if matching against newline characters.
+        // pattern: /^<details><summary>(.*?)<\/summary>(.*?)<\/details>$/ms,
+        pattern: /^::: fyi *\n(.*?)^:::.*$/ms,
+        // Given a RegExp Match object
+        // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
+        // return an object with one property for each field defined in `fields`.
+        //
+        // This is used to populate the custom widget in the markdown editor in the CMS.
+        fromBlock: function (match) {
+          return {
+            contents: match[1],
+          };
+        },
+        // Given an object with one property for each field defined in `fields`,
+        // return the string you wish to be inserted into your markdown.
+        //
+        // This is used to serialize the data from the custom widget to the
+        // markdown document
+        toBlock: function (data) {
+          return `::: fyi
+${data.contents}
+:::`;
+        },
+        // Preview output for this component. Can either be a string or a React component
+        // (component gives better render performance)
+        toPreview: function (data) {
+          return `
+<aside class="fyi">
+  ${md.render(data.contents)}
+</aside>
+`;
+        },
+      });
+    </script>
   </body>
 </html>

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -39,7 +39,7 @@
         // Additionally, it's recommended that you use non-greedy capturing groups (e.g.
         // `(.*?)` vs `(.*)`), especially if matching against newline characters.
         // pattern: /^<details><summary>(.*?)<\/summary>(.*?)<\/details>$/ms,
-        pattern: /^::: fyi *\n(.*?)^:::.*$/ms,
+        pattern: /^::: fyi *\n(.*?)^::: *$/ms,
         // Given a RegExp Match object
         // (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#return_value),
         // return an object with one property for each field defined in `fields`.

--- a/src/css/_fyi.scss
+++ b/src/css/_fyi.scss
@@ -1,4 +1,6 @@
 aside.fyi {
-  padding: var(--space-m);
+  border-radius: var(--space-xs-s);
+  color: var(--color-yellow-dark);
+  padding: var(--space-s-m);
   background-color: var(--color-yellow-light);
 }

--- a/src/css/_fyi.scss
+++ b/src/css/_fyi.scss
@@ -1,0 +1,4 @@
+aside.fyi {
+  padding: var(--space-m);
+  background-color: var(--color-yellow-light);
+}

--- a/src/css/_vars.scss
+++ b/src/css/_vars.scss
@@ -22,7 +22,7 @@
   --color-green-light: hsl(152, 37%, 71%);
   --color-green-dark: hsl(152, 37%, 51%);
   --color-yellow-light: hsl(57, 86%, 89%);
-  --color-yellow-dark: hsl(57, 86%, 69%);
+  --color-yellow-dark: hsl(57.14, 47.37%, 26.08%);
   --color-brown-light: hsl(7, 23%, 77%);
   --color-brown-dark: hsl(7, 23%, 57%);
 

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -11,3 +11,4 @@
 @use "center";
 @use "stack";
 @use "slider";
+@use "fyi";


### PR DESCRIPTION
Add the ability to make little blocks of highlighted content in the markdown editor, I called it the `fyi` element.

<img width="1916" height="1028" alt="Screenshot 2025-08-12 at 18-14-15 Breathe Easy Sheffield" src="https://github.com/user-attachments/assets/4936aab5-debd-4623-b989-b7e567579f53" />


write like this using `::: fyi / :::` on newlines surrounding the content you want to highlight

```markdown


💃 Do you enjoy going out and socialising, but feel cautious since the
covid-19 pandemic? Are you avoiding crowded and indoor venues? You are
not alone!

::: fyi


🎉 Some useful info that you isn't part of the main text! You can use this
to flag up some helpful resource or action related to the content

:::

😷 Many people are still conscious of the risks of attending
in-person events, especially people who are clinically vulnerable to
covid-19 and other infectious diseases.

```

alternatively you can use the rich text editor, but FYI the preview won't be anything fancy, you'll have to check the deploy preview for that or just trust it will look highlighted.


https://github.com/user-attachments/assets/4224bedd-19f5-4354-8149-ebdbbb8c4a58



