### PR TITLE
Folding table of contents

### DIFF
--- a/src/_components/TOC.tsx
+++ b/src/_components/TOC.tsx
@@ -7,18 +7,19 @@ import * as Belt from "@mobily/ts-belt";
 /** Attribute which if found on a heading means the heading is excluded */
 const ignoreAttribute = "data-toc-exclude";
 
+type TOCOpts = {
+  tags?: HeadingLevel[];
+};
+
+type HeadingLevel = "h2" | "h3" | "h4" | "h5" | "h6";
+
 const defaults = {
-  tags: [
-    "h2",
-    "h3",
-    // "h4",
-    // "h5",
-  ],
-  ignoredElements: [],
-  wrapper: "nav",
-  wrapperClass: "toc",
-  headingText: "",
-  headingTag: "h2",
+  tags: ["h2", "h3"],
+  // ignoredElements: [],
+  // wrapper: "nav",
+  // wrapperClass: "toc",
+  // headingText: "",
+  // headingTag: "h2",
 };
 
 const toLevel = (tagName: string): number => {
@@ -62,10 +63,11 @@ const doToc = (aom: Tree.Tree<Element>): JSX.Element => {
   }
 };
 
-export const TOC = (content: string): JSX.Element => {
+export const TOC = (content: string, opts: TOCOpts = {}): JSX.Element => {
+  const opts_ = { ...defaults, ...opts };
   const hdom = HappyDom.dom(content);
   const result = Belt.pipe(
-    defaults.tags,
+    opts_.tags,
     (ts) => ts.map((s) => `${s}[id]`).join(","),
     (q) => hdom.querySelectorAll(q),
     (hs) => hs.filter((h) => !h.hasAttribute(ignoreAttribute)),

--- a/src/_components/TOC.tsx
+++ b/src/_components/TOC.tsx
@@ -68,6 +68,7 @@ export const TOC = (content: string): JSX.Element => {
     defaults.tags,
     (ts) => ts.map((s) => `${s}[id]`).join(","),
     (q) => hdom.querySelectorAll(q),
+    (hs) => hs.filter((h) => !h.hasAttribute(ignoreAttribute)),
     (hs) => Tree.fromArray(shouldBeChild)(hs),
     (tree) => doToc(tree),
   );

--- a/src/_components/TOC.tsx
+++ b/src/_components/TOC.tsx
@@ -10,7 +10,7 @@ const ignoreAttribute = "data-toc-exclude";
 const defaults = {
   tags: [
     "h2",
-    // "h3",
+    "h3",
     // "h4",
     // "h5",
   ],
@@ -47,8 +47,15 @@ const doToc = (aom: Tree.Tree<Element>): JSX.Element => {
         default:
           return (
             <li>
-              <a href={`#${aom.a.id}`}>{aom.a.textContent}</a>{" "}
-              <ul>{aom.children.map(doToc)}</ul>
+              <details>
+                <summary>{aom.a.textContent}</summary>
+                <ul>
+                  <li>
+                    <a href={`#${aom.a.id}`}>Introduction</a>
+                  </li>
+                  {aom.children.map(doToc)}
+                </ul>
+              </details>
             </li>
           );
       }


### PR DESCRIPTION
Expand sub sections in the TOC so people can get to the topic they are interested in.

https://folding-toc.sheffield-breathe-easy-uk.pages.dev/how-to-guide-for-covid-safer-events/

I went with "introduction" as the top level link for a section with sub-sections as I didn't want to repeat the title again.
