### PR TITLE
fix: simplify header.

### DIFF
--- a/src/_components/Header.tsx
+++ b/src/_components/Header.tsx
@@ -11,10 +11,12 @@ export const Header = ({ links, currentUrl }: HeaderProps): JSX.Element => {
   return (
     <header className="header">
       <nav>
-        <a aria-current={currentUrl === "/" ? "page" : null} href="/">
-          Home
-        </a>
         <ul role="list">
+          <li>
+            <a aria-current={currentUrl === "/" ? "page" : null} href="/">
+              Home
+            </a>
+          </li>
           {links.map(({ title, url }) => (
             <li>
               <a aria-current={currentUrl === url ? "page" : null} href={url}>

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -1,16 +1,13 @@
 .header nav {
   background-color: var(--color-bg);
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  padding: var(--space-m);
+  padding-block: var(--space-m);
+  padding-inline: var(--space-m-l);
 }
 
 .header nav ul {
   display: flex;
   margin: 0;
   flex-wrap: wrap;
-  justify-content: flex-end;
   align-items: center;
 }
 


### PR DESCRIPTION
A quick fix before we decide on a more ideal nav setup, preventing this awkward collapsing with extra menu items

<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/6e291b50-7faa-47eb-aac3-693f2cbc439e" />

Currently collapses like this, safe down to 300px


https://github.com/user-attachments/assets/ef4ca7d7-dd5e-47c3-8436-4510c86c8638

