### PR TITLE
constrain the max height of images in the markdown content

### DIFF
--- a/src/_includes/IndexLayout.11ty.tsx
+++ b/src/_includes/IndexLayout.11ty.tsx
@@ -19,7 +19,7 @@ export const IndexLayout = (data: ViewInput): JSX.Element => {
         <main id="main">
           <Section>
             <Hero title={title}></Hero>
-            {content}
+            <div className="content stack">{content}</div>
           </Section>
         </main>
       </body>

--- a/src/_includes/PageLayout.11ty.tsx
+++ b/src/_includes/PageLayout.11ty.tsx
@@ -17,7 +17,7 @@ export function PageLayout(data: ViewInput): JSX.Element {
         <main id="main">
           <Section>
             <h1>{title}</h1>
-            {content}
+            <div className="content stack">{content}</div>
           </Section>
         </main>
       </body>

--- a/src/_includes/ResourceLayout.11ty.tsx
+++ b/src/_includes/ResourceLayout.11ty.tsx
@@ -35,7 +35,11 @@ export function ResourceLayout(data: ViewInput): JSX.Element {
                   </Section>
                 </Slider>
               }
-              notSidebar={<Section>{content}</Section>}
+              notSidebar={
+                <Section>
+                  <div className="content stack">{content}</div>
+                </Section>
+              }
             />
           </div>
         </main>

--- a/src/css/_markdownContent.scss
+++ b/src/css/_markdownContent.scss
@@ -1,0 +1,4 @@
+.content img {
+  max-height: 90vh;
+  margin-inline: auto;
+}

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -4,6 +4,7 @@
 @use "utils";
 @use "base";
 @use "headingLinks";
+@use "markdownContent";
 // component-like things
 @use "header";
 @use "hero";


### PR DESCRIPTION
requested by @JCrafty1

previously images are constrained by width so you can see the whole image in one go without scrolling.
